### PR TITLE
REMOVE progressImage

### DIFF
--- a/src/Bar.tsx
+++ b/src/Bar.tsx
@@ -63,11 +63,6 @@ export type ProgressBarProps = {
   trackColor?: string;
 
   /**
-   * A stretchable image to display as the progress bar.
-   */
-  progressImage?: ImageURISource | ImageURISource[];
-
-  /**
    * A stretchable image to display behind the progress bar.
    */
   trackImage?: ImageURISource | ImageURISource[];
@@ -140,7 +135,6 @@ function ProgressBar({
   trackColor = 'transparent',
   style,
   trackImage,
-  progressImage,
 }: ProgressBarProps) {
   const [width, setWidth] = React.useState(0);
   const progressValue = useValue(isAnimated ? 0 : progress);
@@ -228,7 +222,6 @@ function ProgressBar({
           },
         ]}
         // @ts-ignore
-        source={progressImage}
       />
     </ImageBackground>
   );


### PR DESCRIPTION
`source={progressImage}` was causing `globalThis is not defined` error.
try without progressImage defined and see if this fixes the issue.

ReferenceError
globalThis is not defined
mechanism
onerror
handled
false

```
../src/Bar.tsx in progressImage at line 231:17
1

            backgroundColor: color,
            borderRadius,
          },
        ]}
        // @ts-ignore
        source={progressImage}
      />
    </ImageBackground>
```